### PR TITLE
Enhancement: Add missing -DebugFlag parameter and rename $g_debugFlag to $DebugFlag

### DIFF
--- a/src/Log-Rotate/classes/BlockFactory.ps1
+++ b/src/Log-Rotate/classes/BlockFactory.ps1
@@ -113,7 +113,6 @@ $BlockFactory = [PSCustomObject]@{
                 $yes = $_.Value
 
                 if ( $child.ContainsKey($yes) -and (!$child.ContainsKey($no)) -and $parent.ContainsKey($no) ) {
-                    if ($g_debugFlag -band 4) { Write-Verbose "I said $yes, I didn't say $no, although my parent said $no, I'll still go ahead." }
                     $my_options.Remove($no)
                 }
             }

--- a/src/Log-Rotate/classes/LogFactory.ps1
+++ b/src/Log-Rotate/classes/LogFactory.ps1
@@ -67,7 +67,7 @@ $LogFactory | Add-Member -Name 'InitStatus' -MemberType ScriptMethod -Value {
                 # The reason for using the following code is only because the cmdlets such as Convert-Path, Resolve-Path must point to an existing item.
                 # If debugging didn't create the file, we would have to manually normalize the status file path (i.e. get it's absolute path).
                 <#
-                if ($g_debugFlag) {
+                if ($DebugFlag) {
                     $is_home = $statusfile_path -match '^~'
                     if ($is_home) {
                         # It's an absolute path
@@ -127,7 +127,7 @@ $LogFactory | Add-Member -Name 'InitStatus' -MemberType ScriptMethod -Value {
     # Always test for write permissions on the status file
     try {
         '' | Out-File $this.StatusFile_FullName -Append -Force
-        if (!$status -and $g_debugFlag) {
+        if (!$status -and $DebugFlag) {
             # We're running Log-Rotate the first time in debug mode.
             Remove-Item $this.StatusFile_FullName
         }
@@ -161,7 +161,7 @@ $LogFactory | Add-Member -Name 'GetAll' -MemberType ScriptMethod -Value {
 $LogFactory | Add-Member -Name 'DumpStatus' -MemberType ScriptMethod -Value {
 
     try {
-        if (!$g_debugFlag) {
+        if (!$DebugFlag) {
             # Update my state with each logs rotation status
             $this.GetAll() | Where-Object { $_.Status['rotation_datetime'] } | ForEach-Object {
                 $rotationDateISO = $_.Status['rotation_datetime'].ToString('s')

--- a/src/Log-Rotate/classes/LogObject.ps1
+++ b/src/Log-Rotate/classes/LogObject.ps1
@@ -22,12 +22,12 @@ $LogObject = [PSCustomObject]@{
                         # File exists.
                         Write-Verbose "Error creating output file $my_previous_fullname`: File exists"
                     }else {
-                        if (!$g_debugFlag) {
+                        if (!$DebugFlag) {
                             Copy-Item $my_fullname $my_previous_fullname -ErrorAction Stop
                         }
                         if ($copytruncate) {
                             Write-Verbose "Truncating $my_fullname"
-                            if (!$g_debugFlag) {
+                            if (!$DebugFlag) {
                                 Clear-Content $my_fullname
                             }
                         }else {
@@ -41,12 +41,12 @@ $LogObject = [PSCustomObject]@{
                         # File exists.
                         Write-Verbose "Error creating output file $my_previous_fullname`: File exists"
                     }else {
-                        if (!$g_debugFlag) {
+                        if (!$DebugFlag) {
                             Move-Item $my_fullname $my_previous_fullname -Force
                         }
                         if ($create) {
                             Write-Verbose "Creating new log file $my_fullname"
-                            if (!$g_debugFlag) {
+                            if (!$DebugFlag) {
                                 $newitem = New-Item $my_fullname -ItemType File | Out-Null
                                 if ($newitem) {
 
@@ -102,7 +102,7 @@ $LogObject = [PSCustomObject]@{
 
                         # Rename old logs
                         Write-Verbose "Renaming $source_fullName to $destination_fullName (rotatecount $rotate, logstart $start, i $i)"
-                        if ($g_debugFlag) { continue }
+                        if ($DebugFlag) { continue }
                         if (Test-Path $source_fullName) {
                             Try {
                                 Move-Item -Path $source_fullName -Destination $destination_fullName -Force
@@ -135,7 +135,7 @@ $LogObject = [PSCustomObject]@{
                     $params = @( 'rn', $fullName, '*', $baseName )
                     try {
                         Write-Verbose "Rename log inside compressed archive $fullName to $baseName"
-                        if ($g_debugFlag) {
+                        if ($DebugFlag) {
                             continue
                         }
 
@@ -189,7 +189,7 @@ $LogObject = [PSCustomObject]@{
             try {
                 Write-Verbose "Compressing log with: $compresscmd"
                 Write-Verbose "Compress command line: $compresscmd $( $params -join ' ' )"
-                if ($g_debugFlag) {
+                if ($DebugFlag) {
                     return
                 }
 
@@ -342,7 +342,7 @@ $LogObject = [PSCustomObject]@{
                 }
 
                 # Delete file
-                if (!$g_debugFlag) {
+                if (!$DebugFlag) {
                     Remove-Item $file_fullname
                 }else {
                     # For debugging to simulate deleted file
@@ -1047,8 +1047,8 @@ $LogObject | Add-Member -Name 'PostPostRotate' -MemberType ScriptMethod -Value {
             if ($rotate -gt 0) {
                 $keep_prev_count = $rotate
                 $prev_files = Get-Files $my_previous_noncompressed_regex $my_previous_directory | Where-Object {
-                                                                                                        !$g_debugFlag -or
-                                                                                                        ($g_debugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
+                                                                                                        !$DebugFlag -or
+                                                                                                        ($DebugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
                                                                                                     }
 
                 Remove-Old-Files $prev_files $keep_prev_count 1
@@ -1091,8 +1091,8 @@ $LogObject | Add-Member -Name 'PostPostRotate' -MemberType ScriptMethod -Value {
             # Delete old compressed logs
             if ($rotate -gt 0) {
                 $prev_files = Get-Files $my_previous_compressed_regex $my_previous_directory | Where-Object {
-                    !$g_debugFlag -or
-                    ($g_debugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
+                    !$DebugFlag -or
+                    ($DebugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
                 }
                 Remove-Old-Files $prev_files $keep_prev_compressed_count 1
             }

--- a/src/Log-Rotate/classes/New-BlockFactory.ps1
+++ b/src/Log-Rotate/classes/New-BlockFactory.ps1
@@ -113,7 +113,6 @@ function New-BlockFactory {
                     $yes = $_.Value
 
                     if ( $child.ContainsKey($yes) -and (!$child.ContainsKey($no)) -and $parent.ContainsKey($no) ) {
-                        if ($g_debugFlag -band 4) { Write-Verbose "I said $yes, I didn't say $no, although my parent said $no, I'll still go ahead." }
                         $my_options.Remove($no)
                     }
                 }

--- a/src/Log-Rotate/classes/New-LogFactory.ps1
+++ b/src/Log-Rotate/classes/New-LogFactory.ps1
@@ -68,7 +68,7 @@ function New-LogFactory {
                     # The reason for using the following code is only because the cmdlets such as Convert-Path, Resolve-Path must point to an existing item.
                     # If debugging didn't create the file, we would have to manually normalize the status file path (i.e. get it's absolute path).
                     <#
-                    if ($g_debugFlag) {
+                    if ($DebugFlag) {
                         $is_home = $statusfile_path -match '^~'
                         if ($is_home) {
                             # It's an absolute path
@@ -128,7 +128,7 @@ function New-LogFactory {
         # Always test for write permissions on the status file
         try {
             '' | Out-File $this.StatusFile_FullName -Append -Force
-            if (!$status -and $g_debugFlag) {
+            if (!$status -and $DebugFlag) {
                 # We're running Log-Rotate the first time in debug mode.
                 Remove-Item $this.StatusFile_FullName
             }
@@ -162,7 +162,7 @@ function New-LogFactory {
     $LogFactory | Add-Member -Name 'DumpStatus' -MemberType ScriptMethod -Value {
 
         try {
-            if (!$g_debugFlag) {
+            if (!$DebugFlag) {
                 # Update my state with each logs rotation status
                 $this.GetAll() | Where-Object { $_.Status['rotation_datetime'] } | ForEach-Object {
                     $rotationDateISO = $_.Status['rotation_datetime'].ToString('s')

--- a/src/Log-Rotate/classes/New-LogObject.ps1
+++ b/src/Log-Rotate/classes/New-LogObject.ps1
@@ -23,12 +23,12 @@ function New-LogObject {
                             # File exists.
                             Write-Verbose "Error creating output file $my_previous_fullname`: File exists"
                         }else {
-                            if (!$g_debugFlag) {
+                            if (!$DebugFlag) {
                                 Copy-Item $my_fullname $my_previous_fullname -ErrorAction Stop
                             }
                             if ($copytruncate) {
                                 Write-Verbose "Truncating $my_fullname"
-                                if (!$g_debugFlag) {
+                                if (!$DebugFlag) {
                                     Clear-Content $my_fullname
                                 }
                             }else {
@@ -42,12 +42,12 @@ function New-LogObject {
                             # File exists.
                             Write-Verbose "Error creating output file $my_previous_fullname`: File exists"
                         }else {
-                            if (!$g_debugFlag) {
+                            if (!$DebugFlag) {
                                 Move-Item $my_fullname $my_previous_fullname -Force
                             }
                             if ($create) {
                                 Write-Verbose "Creating new log file $my_fullname"
-                                if (!$g_debugFlag) {
+                                if (!$DebugFlag) {
                                     $newitem = New-Item $my_fullname -ItemType File | Out-Null
                                     if ($newitem) {
 
@@ -103,7 +103,7 @@ function New-LogObject {
 
                             # Rename old logs
                             Write-Verbose "Renaming $source_fullName to $destination_fullName (rotatecount $rotate, logstart $start, i $i)"
-                            if ($g_debugFlag) { continue }
+                            if ($DebugFlag) { continue }
                             if (Test-Path $source_fullName) {
                                 Try {
                                     Move-Item -Path $source_fullName -Destination $destination_fullName -Force
@@ -136,7 +136,7 @@ function New-LogObject {
                         $params = @( 'rn', $fullName, '*', $baseName )
                         try {
                             Write-Verbose "Rename log inside compressed archive $fullName to $baseName"
-                            if ($g_debugFlag) {
+                            if ($DebugFlag) {
                                 continue
                             }
 
@@ -190,7 +190,7 @@ function New-LogObject {
                 try {
                     Write-Verbose "Compressing log with: $compresscmd"
                     Write-Verbose "Compress command line: $compresscmd $( $params -join ' ' )"
-                    if ($g_debugFlag) {
+                    if ($DebugFlag) {
                         return
                     }
 
@@ -343,7 +343,7 @@ function New-LogObject {
                     }
 
                     # Delete file
-                    if (!$g_debugFlag) {
+                    if (!$DebugFlag) {
                         Remove-Item $file_fullname
                     }else {
                         # For debugging to simulate deleted file
@@ -1047,8 +1047,8 @@ function New-LogObject {
                 if ($rotate -gt 0) {
                     $keep_prev_count = $rotate
                     $prev_files = Get-Files $my_previous_noncompressed_regex $my_previous_directory | Where-Object {
-                                                                                                            !$g_debugFlag -or
-                                                                                                            ($g_debugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
+                                                                                                            !$DebugFlag -or
+                                                                                                            ($DebugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
                                                                                                         }
 
                     Remove-Old-Files $prev_files $keep_prev_count 1
@@ -1091,8 +1091,8 @@ function New-LogObject {
                 # Delete old compressed logs
                 if ($rotate -gt 0) {
                     $prev_files = Get-Files $my_previous_compressed_regex $my_previous_directory | Where-Object {
-                        !$g_debugFlag -or
-                        ($g_debugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
+                        !$DebugFlag -or
+                        ($DebugFlag -and $_.FullName -notin $debug_my_prevfilespurged_fullnames )
                     }
                     Remove-Old-Files $prev_files $keep_prev_compressed_count 1
                 }

--- a/src/Log-Rotate/helpers/Get-Exception-Message.ps1
+++ b/src/Log-Rotate/helpers/Get-Exception-Message.ps1
@@ -8,7 +8,7 @@ function Get-Exception-Message ($ErrorRecord) {
         }
     }
     $Message = Get-InnerExceptionMessage $ErrorRecord.Exception
-    if ($g_debugFlag -band 2) {
+    if ($DebugFlag -band 2) {
         $Message = $Message  + "`nStacktrace:`n" + $ErrorRecord.Exception.ErrorRecord.ScriptStackTrace
     }
     $Message

--- a/src/Log-Rotate/helpers/Start-Script.ps1
+++ b/src/Log-Rotate/helpers/Start-Script.ps1
@@ -10,15 +10,13 @@ function Start-Script {
         # Save the caller's ErrorAction
         $callerEA = $ErrorActionPreference
         $ErrorActionPreference = 'Stop'
-        if ($g_debugFlag -band 4) { Write-Verbose "[Start-Script] callerEA: $callerEA" }
-        if ($g_debugFlag -band 4) { Write-Verbose "[Start-Script] ErrorActionPreference: $ErrorActionPreference" }
     }
 
     process {
         try {
             Write-Verbose "Running script with arg $file_FullName : `n$script"
             $OS = $ENV:OS
-            if (!$g_debugFlag) {
+            if (!$DebugFlag) {
                 if ($OS -eq "Windows_NT") {
                     # E.g. & Powershell -Command { echo $Args[0] } -Args @('D:/console.log')
 

--- a/src/Log-Rotate/private/rotate/Process-Local-Block.ps1
+++ b/src/Log-Rotate/private/rotate/Process-Local-Block.ps1
@@ -304,7 +304,7 @@ function Process-Local-Block  {
                         }
                     }
                 }else {
-                    if ($g_debugFlag) {
+                    if ($DebugFlag) {
                         Write-Verbose "Not running first action script, since no logs will be rotated"
                         Write-Verbose "Not running prerotate script, since no logs will be rotated"
                         Write-Verbose "Not running postrotate script, since no logs will be rotated"

--- a/src/Log-Rotate/public/Log-Rotate.ps1
+++ b/src/Log-Rotate/public/Log-Rotate.ps1
@@ -71,6 +71,9 @@ function Log-Rotate {
         [alias("c")]
         [string[]]$Config
     ,
+        [alias("d")]
+        [string[]]$DebugFlag
+    ,
         [alias("f")]
         [switch]$Force
     ,
@@ -90,7 +93,7 @@ function Log-Rotate {
         [switch]$Version
     )
 
-    if ($debug) {
+    if ($DebugFlag) {
         Write-Warning "We are in Debug mode. No logs will be rotated."
     }
     if ($Force) {
@@ -104,8 +107,8 @@ function Log-Rotate {
     # 1 - On, script does not change files. Calling Log-Rotate with -Debug will switch this to 1.
     # 2 - Output Stacktrace in error messages
     # 4 - On, verbose mode. Implies (1). This is NOT related to calling Log-Rotate with -Verbose, but strictly for debugging messages.
-    $g_debugFlag = 0
-    if ($g_debugFlag) {
+    $DebugFlag = 0
+    if ($DebugFlag) {
         Write-Warning "Developer's debug flag is on."
     }
 
@@ -122,7 +125,7 @@ function Log-Rotate {
         # If we're using the -debug flag, always use -verbose mode.
         $DebugPreference = 'Continue'
         # Preserve our set debug flag for testing
-        $g_debugFlag = if ($g_debugFlag) { $g_debugFlag } else { 1 }
+        $DebugFlag = if ($DebugFlag) { $DebugFlag } else { 1 }
     }else {
          # If we're not using the -debug flag, debug should stay silent instead of prompting.
         $DebugPreference = 'SilentlyContinue'
@@ -159,9 +162,6 @@ function Log-Rotate {
         #Write-Verbose "Current working directory: $( Convert-Path . )"
         Write-Verbose "Current working directory: $( $(Get-Location).Path )"
 
-        # Debug
-        if ($g_debugFlag -band 4) { Write-Verbose "Verbose stream: $VerbosePreference" }
-        if ($g_debugFlag -band 4) { Write-Verbose "Debug stream: $DebugPreference" }
 
         # Get the configuration as a string
         if ($ConfigAsString) {
@@ -239,6 +239,6 @@ function Log-Rotate {
         # Finish up with dumping status
         $LogFactory.DumpStatus()
     }catch {
-        Write-Error "Stopped with errors. $(Get-Exception-Message $_)" -ErrorAction $CallerEA
+        Write-Error -Exception $_.Exception -ErrorAction $CallerEA
     }
 }


### PR DESCRIPTION
Previously it was not possible to specify the -d or -DebugFlag on the command line. So we add a -DebugFlag parameter. We cannot call it -Debug, since -Debug is reserved for CmdletBinding().