### PR TITLE
Fix: Use Test-Path -PathType Container instead of $item.PSIsContainer

### DIFF
--- a/src/Log-Rotate/classes/New-BlockFactory.ps1
+++ b/src/Log-Rotate/classes/New-BlockFactory.ps1
@@ -168,7 +168,7 @@ function New-BlockFactory {
 
                         if (Test-Path -LiteralPath $logpath) {
                             $item = Get-Item -Path $logpath
-                            if ($item.PSIsContainer) {
+                            if (Test-Path $item.FullName -PathType Container) {
                                 # It's a directory. Ignore it.
                                 if (!$opt_missingok) {
                                     Write-Verbose "Excluding path $logpath for rotation, because it is a directory. Directories cannot be rotated. If rotating all the files in the directory, append a wildcard to the end of the path."

--- a/src/Log-Rotate/classes/New-LogFactory.ps1
+++ b/src/Log-Rotate/classes/New-LogFactory.ps1
@@ -35,7 +35,7 @@ function New-LogFactory {
             if ($exists) {
                 # Ensure it's not an existing diretory
                 $item = Get-Item $statusfile_path -ErrorAction Stop
-                if ($item.PSIsContainer) {
+                if (Test-Path $item.FullName -PathType Container) {
                     throw "STATUSFILE: WARNING: Invalid status file $statusfile_path . It points to an existing directory $($item.FullName)."
                 }
 

--- a/src/Log-Rotate/private/config/Compile-Full-Config.ps1
+++ b/src/Log-Rotate/private/config/Compile-Full-Config.ps1
@@ -9,7 +9,7 @@ function Compile-Full-Config {
         if ($include_path -and (Test-Path $include_path))  {
             $item = Get-Item $include_path
 
-            if ($item.PSIsContainer) {
+            if (Test-Path $item.FullName -PathType Container) {
                 # It's a directory. Include content of all files inside it
                 $content = ""
                 Get-ChildItem $item | ForEach-Object {

--- a/src/Log-Rotate/public/Log-Rotate.ps1
+++ b/src/Log-Rotate/public/Log-Rotate.ps1
@@ -180,7 +180,7 @@ function Log-Rotate {
                     if (Test-Path $_) {
 
                         $item = Get-Item $_
-                        if ($item.PSIsContainer) {
+                        if (Test-Path $item.FullName -PathType Container) {
                             # It's a directory. Consider all child files as config files.
                             Get-ChildItem $item.FullName -File | ForEach-Object {
                                 Write-Verbose "Config file found: $($_.FullName)"


### PR DESCRIPTION
This will help ease test mocking.