### PR TITLE
Fix (tests): Fix integration tests failing in many versions of powershell

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -119,7 +119,8 @@ jobs:
     runs-on: ubuntu-16.04
     container:
       # image: theohbrothers/docker-powershell:6.1.3-alpine-3.8-git
-      image: mcr.microsoft.com/powershell:6.1.3-alpine-3.8
+      # image: mcr.microsoft.com/powershell:6.1.3-alpine-3.8
+      image: mcr.microsoft.com/powershell:6.1.3-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Display system info (linux)
@@ -143,7 +144,8 @@ jobs:
     runs-on: ubuntu-16.04
     container:
       # image: theohbrothers/docker-powershell:6.2.4-alpine-3.8-git
-      image: mcr.microsoft.com/powershell:6.2.4-alpine-3.8
+      # image: mcr.microsoft.com/powershell:6.2.4-alpine-3.8
+      image: mcr.microsoft.com/powershell:6.2.4-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Display system info (linux)
@@ -167,7 +169,8 @@ jobs:
     runs-on: ubuntu-16.04
     container:
       # image: theohbrothers/docker-powershell:7.0.3-alpine-3.9-20200928
-      image: mcr.microsoft.com/powershell:7.0.3-alpine-3.9
+      # image: mcr.microsoft.com/powershell:7.0.3-alpine-3.9
+      image: mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Display system info (linux)
@@ -191,7 +194,8 @@ jobs:
     runs-on: ubuntu-16.04
     container:
       # image: theohbrothers/docker-powershell:7.1.3-alpine-3.11-20210316-git
-      image: mcr.microsoft.com/powershell:7.1.3-alpine-3.11-20210316
+      # image: mcr.microsoft.com/powershell:7.1.3-alpine-3.11-20210316
+      image: mcr.microsoft.com/powershell:7.1.3-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Display system info (linux)
@@ -215,7 +219,8 @@ jobs:
     runs-on: ubuntu-16.04
     container:
       # image: theohbrothers/docker-powershell:7.2.0-preview.4-alpine-3.11-20210316-git
-      image: mcr.microsoft.com/powershell:7.2.0-preview.4-alpine-3.11-20210316
+      # image: mcr.microsoft.com/powershell:7.2.0-preview.4-alpine-3.11-20210316
+      image: mcr.microsoft.com/powershell:7.2.0-preview.4-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Display system info (linux)

--- a/src/Log-Rotate/public/Log-Rotate.Integration.Tests.ps1
+++ b/src/Log-Rotate/public/Log-Rotate.Integration.Tests.ps1
@@ -34,21 +34,32 @@ Describe 'Log-Rotate' -Tag 'Integration' {
     function Init  {
         New-Item $configDir -ItemType Directory -Force > $null
         New-Item $configFile -ItemType File -Force > $null
-        $configFileContent | Out-File $configFile -Encoding utf8 -Force -NoNewline
+        # Do not write an empty file with BOM in Powershell <= 5
+        if ($configFileContent) {
+            $configFileContent | Out-File $configFile -Encoding utf8 -Force -NoNewline
+        }
 
         New-Item $configDir2 -ItemType Directory -Force > $null
         New-Item $configFile2 -ItemType File -Force > $null
-        $configFile2Content | Out-File $configFile2 -Encoding utf8 -Force -NoNewline
+        # Do not write an empty file with BOM in Powershell <= 5
+        if ($configFile2Content) {
+            $configFile2Content | Out-File $configFile2 -Encoding utf8 -Force -NoNewline
+        }
 
         New-Item $logDir -ItemType Directory -Force > $null
         New-Item $logOldDir -ItemType Directory -Force > $null
         New-Item $logFile -ItemType File -Force > $null
-        $logFileContent | Out-File $logFile -Encoding utf8 -Force -NoNewline
+        # Do not write an empty file with BOM in Powershell <= 5
+        if ($logFileContent) {
+            $logFileContent | Out-File $logFile -Encoding utf8 -Force -NoNewline
+        }
 
         New-Item $logDir2 -ItemType Directory -Force > $null
         New-Item $logOldDir2 -ItemType Directory -Force > $null
         New-Item $logFile2 -ItemType File -Force > $null
-        $logFile2Content | Out-File $logFile2 -Encoding utf8 -Force -NoNewline
+        if ($logFile2Content) {
+            $logFile2Content | Out-File $logFile2 -Encoding utf8 -Force -NoNewline
+        }
 
         New-Item $stateDir -ItemType Directory -Force > $null
     }


### PR DESCRIPTION
For pwsh >= 6, use an ubuntu docker image with GNU gzip. Tests were failing because of alpine gzip.
    
For powershell <= 5, ensure created log files at Init of each integration test do not contain a BOM.