### PR TITLE
Fix: Fix `create` option to work correctly when optional attributes are omitted

### DIFF
--- a/src/Log-Rotate/Log-Rotate.Integration.Tests.ps1
+++ b/src/Log-Rotate/Log-Rotate.Integration.Tests.ps1
@@ -298,7 +298,32 @@ Describe 'Log-Rotate' -Tag 'Integration' {
             $logFileHash.Hash | Should -Not -Be $rotatedLogFileHash.Hash
         }
 
-        It "Option 'create': rotates a log file and immediately creates a new original file" {
+        It "Option 'create' (without attributes): rotates a log file and immediately creates a new original file" {
+            $configFileContent = @"
+"$logFile" {
+    create
+}
+"@
+            Init
+
+            Log-Rotate -config $configFile -State $stateFile -ErrorAction $eaPreference #-Verbose
+
+            # Assert that the log file should remain
+            $logItem = Get-Item $logFile -ErrorAction SilentlyContinue
+            $logItem | Should -BeOfType [System.IO.FileSystemInfo]
+            $logItem.Name | Should -Be "$( Split-Path $logFile -Leaf )"
+            $logItem.Length | Should -Be 0
+
+            # Assert that the rotated log file should be there
+            $rotatedLogItems = @( Get-Item $logDir/* )
+            $rotatedLogItems.Count | Should -Be 2
+            $rotatedLogItems[1] | Should -BeOfType [System.IO.FileSystemInfo]
+
+            # Assert that the rotated log file should be named
+            $rotatedLogItems[1].Name | Should -Be "$( Split-Path $logFile -Leaf ).1"
+        }
+
+        It "Option 'create' (with mode, owner, and group attributes): rotates a log file and immediately creates a new original file" {
             $configFileContent = @"
 "$logFile" {
     create 700 1000 1000

--- a/src/Log-Rotate/private/rotate/Process-Local-Block.ps1
+++ b/src/Log-Rotate/private/rotate/Process-Local-Block.ps1
@@ -91,7 +91,15 @@ function Process-Local-Block  {
                                 $copy
                             }
         $options['copytruncate'] = if ($nocopytruncate) { $false } else { $copytruncate }
-        $options['create'] = if ($nocreate) { '' } else { $create }
+
+        $options['create'] = if ($nocreate) { '' } else {
+            # 'create' option's attributes are optional, in which case its value is an empty string
+            if ($PSBoundParameters.ContainsKey('create') -and $PSBoundParameters['create'] -eq '') {
+                ' ' # Set to a non-empty string
+            }else {
+                $create
+            }
+        }
         $options['delaycompress'] = if ($nodelaycompress) { $false } else { $delaycompress }
         $options['dateext'] = if ($nodateext) { $false } else { $dateext }
         $options['mail'] = if ($nomail) { $false } else { $mail }


### PR DESCRIPTION
According to the logrotate man, `create` option should work when optional attributes are omitted.

Now, the `create` option is fixed to support omission of optional attributes.

Fixes #63
