### PR TITLE
fix delete-clear-opened-text-file-which-is-used-by-another-process

### DIFF
--- a/src/Log-Rotate/classes/New-LogObject.ps1
+++ b/src/Log-Rotate/classes/New-LogObject.ps1
@@ -29,7 +29,7 @@ function New-LogObject {
                             if ($copytruncate) {
                                 Write-Verbose "Truncating $my_fullname"
                                 if (!$WhatIf) {
-                                    "" | Out-File $my_fullname -NoNewline -Encoding ASCII
+                                    "" | Out-File $my_fullname -NoNewline -Encoding utf8
                                 }
                             }else {
                                 Write-Verbose "Not truncating $my_fullname"

--- a/src/Log-Rotate/classes/New-LogObject.ps1
+++ b/src/Log-Rotate/classes/New-LogObject.ps1
@@ -29,7 +29,7 @@ function New-LogObject {
                             if ($copytruncate) {
                                 Write-Verbose "Truncating $my_fullname"
                                 if (!$WhatIf) {
-                                    Clear-Content $my_fullname
+                                    "" | Out-File $my_fullname -NoNewline -Encoding ASCII
                                 }
                             }else {
                                 Write-Verbose "Not truncating $my_fullname"

--- a/src/Log-Rotate/classes/New-LogObject.ps1
+++ b/src/Log-Rotate/classes/New-LogObject.ps1
@@ -29,7 +29,7 @@ function New-LogObject {
                             if ($copytruncate) {
                                 Write-Verbose "Truncating $my_fullname"
                                 if (!$WhatIf) {
-                                    "" | Out-File $my_fullname -NoNewline -Encoding utf8
+                                    "" | Out-File $my_fullname -NoNewline
                                 }
                             }else {
                                 Write-Verbose "Not truncating $my_fullname"


### PR DESCRIPTION
Seems like Clear-Content is creating a new file and replaces the old one with it, while Out-File tries to write into an existing file (so opened read handles do not effect this)

https://stackoverflow.com/questions/46724371/delete-clear-opened-text-file-which-is-used-by-another-process