### PR TITLE
Fix: Fix `copytruncate` to work when another process has an read lock on the log file

### DIFF
--- a/src/Log-Rotate/classes/New-LogObject.ps1
+++ b/src/Log-Rotate/classes/New-LogObject.ps1
@@ -29,7 +29,8 @@ function New-LogObject {
                             if ($copytruncate) {
                                 Write-Verbose "Truncating $my_fullname"
                                 if (!$WhatIf) {
-                                    Clear-Content $my_fullname
+                                    # Truncate the file
+                                    [IO.File]::WriteAllText($my_fullname, '')
                                 }
                             }else {
                                 Write-Verbose "Not truncating $my_fullname"


### PR DESCRIPTION
Fixes #52
